### PR TITLE
Fix to API calls in history browser

### DIFF
--- a/history browser/js/main.js
+++ b/history browser/js/main.js
@@ -70,7 +70,7 @@ $(function() {
     // request object getting the history
     var req = {
         method: 'tx_history',
-        params: [index]
+        params: [{'start' : index}]
     }
 
     // Call for getting the history
@@ -112,7 +112,7 @@ $(function() {
     $('#nextButton').click(function(){
         index += 20;
 
-        req.params = [index];
+        req.params = [{'start' : index}];
         rpc.call(req);
 
         return false;
@@ -122,7 +122,7 @@ $(function() {
     $('#prevButton').click(function(){
         index -= 20;
 
-        req.params = [index];
+        req.params = [{'start' : index}];
         rpc.call(req);
 
         return false;


### PR DESCRIPTION
API call using [index] replaced with {{'start': index}] in history browser/js/main.js 

( 3 times )
- One to fix main screen
- One to fix prev button
- One to fix next button

This code is tested and a working version an be seen at:

http://rippledb.com/ex/history%20browser/
